### PR TITLE
docs: Add supported blockchain networks for sponsor wallet

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,13 @@ This open source web application welcomes sponsors! Support options include:
 
 ### Call for Sponsors
 Cat Lab and LarisLabs are open for funding to support the development and maintenance of this open source FloodBoy web application:
-- **ETH Wallet**: `0x1D7EF8bF25CF7575cD220c33E8b20c02c491261b`
+
+**ETH Wallet**: `0x1D7EF8bF25CF7575cD220c33E8b20c02c491261b`
+
+**Supported Networks**:
+- Ethereum Mainnet
+- Optimism
+- BNB Chain
 
 Your sponsorship will help us improve the dashboard, add new features, and maintain the infrastructure.
 


### PR DESCRIPTION
## Summary
Update the Call for Sponsors section to clearly show which blockchain networks support the ETH wallet address.

## Changes
- Added "Supported Networks" section under the ETH wallet
- Listed 3 major networks: Ethereum Mainnet, Optimism, and BNB Chain
- Makes it easier for sponsors to know where they can send donations

## Before
```
- **ETH Wallet**: `0x1D7EF8bF25CF7575cD220c33E8b20c02c491261b`
```

## After
```
**ETH Wallet**: `0x1D7EF8bF25CF7575cD220c33E8b20c02c491261b`

**Supported Networks**:
- Ethereum Mainnet
- Optimism
- BNB Chain
```

This provides clarity for potential sponsors about which networks they can use for donations.