### PR TITLE
fix: Replace Astro-branded OG image with FloodBoy logo

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -11,7 +11,7 @@ interface Props {
 
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 
-const { title, description, image = '/blog-placeholder-1.jpg' } = Astro.props;
+const { title, description, image = '/floodboy-logo.png' } = Astro.props;
 ---
 
 <!-- Global Metadata -->


### PR DESCRIPTION
## Summary
- Replaced default OG image from Astro-branded placeholder to FloodBoy logo
- All pages now show FloodBoy branding in social media preview shares

## Test plan
- [x] Updated BaseHead.astro default image parameter
- [x] Verified OG meta tags show floodboy-logo.png
- [x] Tested on localhost - confirmed correct image path in meta tags

## Before
Preview shares showed Astro logo with "Build the web you want" text

## After
Preview shares now show FloodBoy logo

Fixes #48

🤖 Generated with [Claude Code](https://claude.ai/code)