### PR TITLE
fix: Show 'No data' instead of zeros for missing sensor values

### DIFF
--- a/src/pages/blockchain/[address].astro
+++ b/src/pages/blockchain/[address].astro
@@ -1356,13 +1356,15 @@ const pageTitle = aliasInfo
 									// Dynamic fields based on actual store data
 									storeData?.fields && storeData.fields.length > 0 ? (
 										storeData.fields.map((field, index) => {
-											let value = 0;
+											let value = null;
+											let hasData = false;
 											// Clean unit display - remove "x 1000", "x1000", " x 1000", etc.
 											let unit = field.unit.replace(/\s*x\s*\d+/gi, '').trim();
 											
 											// Get value from latest record
 											if (sensorRecords.length > 0 && sensorRecords[0].values[index] !== undefined) {
 												value = parseFloat(formatScaledValue(sensorRecords[0].values[index], field.unit));
+												hasData = true;
 											}
 											
 											// Color scheme for different field types
@@ -1377,7 +1379,7 @@ const pageTitle = aliasInfo
 											
 											// Check if this is water level and exceeds sensor range
 											const isWaterLevel = field.name.toLowerCase().includes('water') && field.name.toLowerCase().includes('level');
-											const exceedsSensorRange = isWaterLevel && value > 2.5;
+											const exceedsSensorRange = hasData && isWaterLevel && value > 2.5;
 											
 											return React.createElement('div', { 
 												key: index, 
@@ -1386,8 +1388,10 @@ const pageTitle = aliasInfo
 												React.createElement('div', { className: `text-sm ${exceedsSensorRange ? 'text-red-600' : color.text} font-medium` }, 
 													field.name.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase())
 												),
-												React.createElement('div', { className: `text-2xl font-bold ${exceedsSensorRange ? 'text-red-900' : color.bold}` }, 
-													`${unit.toLowerCase().includes('count') ? Math.round(value) : value.toFixed(unit.includes('V') ? 3 : 2)} ${unit.replace(/ x\d+$/, '')}${exceedsSensorRange ? ' ⚠️' : ''}`
+												React.createElement('div', { className: `text-2xl font-bold ${exceedsSensorRange ? 'text-red-900' : hasData ? color.bold : 'text-gray-400 italic'}` }, 
+													hasData 
+														? `${unit.toLowerCase().includes('count') ? Math.round(value) : value.toFixed(unit.includes('V') ? 3 : 2)} ${unit.replace(/ x\d+$/, '')}${exceedsSensorRange ? ' ⚠️' : ''}`
+														: 'No data'
 												),
 												exceedsSensorRange && React.createElement('div', { className: 'text-xs text-red-600 mt-1' }, 
 													'Exceeds 2.5m sensor range'


### PR DESCRIPTION
## Summary
- Shows "No data" when sensor values are unavailable instead of misleading zeros
- Users can now distinguish between actual zero readings and missing data

## Problem
When sensor data was not available, the UI displayed zero values (0.00) which was misleading:
```
Battery Voltage: 0.000 V
Installation Height: 0.00 m
Water Depth: 0.00 m
```

## Solution
- Initialize value as `null` instead of `0`
- Add `hasData` flag to track when we have actual sensor data
- Display "No data" in gray italic text when no data is available
- Keep actual values (including real zeros) when data exists

## Visual Changes
- **Before**: All missing values show as `0.00`
- **After**: Missing values show as `No data` in gray italic text

## Test plan
- [x] Updated value initialization to use null
- [x] Added hasData flag tracking
- [x] Updated display logic to show "No data"
- [x] Tested sensor range validation still works with hasData check

Fixes #54

🤖 Generated with [Claude Code](https://claude.ai/code)