### PR TITLE
feat: Make installation height dynamic from blockchain data

### DIFF
--- a/src/pages/blockchain/[address].astro
+++ b/src/pages/blockchain/[address].astro
@@ -703,7 +703,7 @@ const pageTitle = aliasInfo
 									
 									// Additional warning text below
 									p.textSize(10);
-									p.text(`Exceeds ${currentInstallationHeight.toFixed(1)}m range`, waterArea + 75, labelY + 15);
+									p.text(`Exceeds ${currentInstallationHeight.toFixed(2)}m range`, waterArea + 75, labelY + 15);
 									p.textSize(12); // Reset text size
 								} else {
 									p.text(currentWaterLevel.toFixed(2) + 'm', sensorX + 5, labelY);
@@ -764,7 +764,7 @@ const pageTitle = aliasInfo
 								p.fill(75, 65, 81); // Dark gray to match sensor color
 								p.textAlign(p.CENTER, p.CENTER);
 								p.textSize(12);
-								p.text(`${currentInstallationHeight.toFixed(1)}m`, boxX + textWidth/2, sensorY);
+								p.text(`${currentInstallationHeight.toFixed(2)}m`, boxX + textWidth/2, sensorY);
 							}
 							
 							p.noStroke();
@@ -1347,7 +1347,7 @@ const pageTitle = aliasInfo
 									React.createElement('div', { className: 'text-center text-sm mt-2' },
 										waterLevel > installationHeight ? 
 											React.createElement('span', { className: 'text-red-600 font-medium' },
-												`⚠️ Water Level: ${waterLevel.toFixed(2)}m (exceeds ${installationHeight.toFixed(1)}m sensor range)`
+												`⚠️ Water Level: ${waterLevel.toFixed(2)}m (exceeds ${installationHeight.toFixed(2)}m sensor range)`
 											) :
 											React.createElement('span', { className: 'text-gray-600' },
 												`Current Water Level: ${waterLevel.toFixed(2)}m`
@@ -1420,7 +1420,7 @@ const pageTitle = aliasInfo
 														: 'No data'
 												),
 												exceedsSensorRange && React.createElement('div', { className: 'text-xs text-red-600 mt-1' }, 
-													`Exceeds ${installationHeight.toFixed(1)}m sensor range`
+													`Exceeds ${installationHeight.toFixed(2)}m sensor range`
 												)
 											);
 										})


### PR DESCRIPTION
## Summary
- Reads installation height from blockchain contract data instead of hardcoding to 2.5m
- Uses dynamic scaling based on actual sensor configuration
- Displays values with 2 decimal precision

## Problem
Installation height was hardcoded to 2.5m throughout the visualization, but different sensors may have different installation heights. The blockchain already supports storing this value.

## Solution
1. **Add installation height state** - Default 3.0m, updated from contract
2. **Extract from contract data** - Read `installation_height` field when available
3. **Dynamic visualization** - Use actual height for:
   - Air level calculation
   - Sensor range validation
   - Warning messages
   - Visual display

## Technical Details
- Uses existing `formatScaledValue` function which dynamically parses scale factor from unit string (e.g., "m x 1000")
- Falls back to 3.0m default when field not available
- Maintains backward compatibility with stores without installation_height field
- Display precision set to 2 decimal places (e.g., "2.50m")

## Test plan
- [x] Installation height extracted from processedData
- [x] Visualization uses dynamic height for calculations
- [x] Sensor range warnings use actual installation height
- [x] Values displayed with 2 decimal precision
- [x] Fallback to 3.0m when field not available

## Visual Changes
- Sensor shows actual installation height (e.g., "2.50m" instead of fixed "2.5m")
- Warning messages show actual range (e.g., "Exceeds 2.50m sensor range")
- Air level calculation uses actual height

Fixes #51

🤖 Generated with [Claude Code](https://claude.ai/code)