### PR TITLE
feat: Implement lastDataTimestamp-based sensor detection with three states

### DIFF
--- a/src/abis/CatLabFactory.json
+++ b/src/abis/CatLabFactory.json
@@ -1,0 +1,971 @@
+[
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "initialOwner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "allStores",
+    "inputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "allStoresCount",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "deployWithDescription",
+    "inputs": [
+      {
+        "name": "fields",
+        "type": "tuple[]",
+        "internalType": "struct CatLabSensorStore.Field[]",
+        "components": [
+          {
+            "name": "name",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "unit",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "dtype",
+            "type": "string",
+            "internalType": "string"
+          }
+        ]
+      },
+      {
+        "name": "nickname",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "description",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "initialSigners",
+        "type": "address[]",
+        "internalType": "address[]"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "store",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "deployWithNickname",
+    "inputs": [
+      {
+        "name": "fields",
+        "type": "tuple[]",
+        "internalType": "struct CatLabSensorStore.Field[]",
+        "components": [
+          {
+            "name": "name",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "unit",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "dtype",
+            "type": "string",
+            "internalType": "string"
+          }
+        ]
+      },
+      {
+        "name": "nickname",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "store",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "factoryDeploymentBlock",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getAddress",
+    "inputs": [
+      {
+        "name": "fields",
+        "type": "tuple[]",
+        "internalType": "struct CatLabSensorStore.Field[]",
+        "components": [
+          {
+            "name": "name",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "unit",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "dtype",
+            "type": "string",
+            "internalType": "string"
+          }
+        ]
+      },
+      {
+        "name": "creator",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "index",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "store",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getAllStoresCount",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getMyStoreByNickname",
+    "inputs": [
+      {
+        "name": "nickname",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getNicknameVersion",
+    "inputs": [
+      {
+        "name": "user",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "nickname",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getStoreByNickname",
+    "inputs": [
+      {
+        "name": "user",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "nickname",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getStoreInfo",
+    "inputs": [
+      {
+        "name": "store",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "nickname",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "authorizedSignerCount",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "deployedBlock",
+        "type": "uint128",
+        "internalType": "uint128"
+      },
+      {
+        "name": "description",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "lastDataTimestamp",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "hasData",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getStoreMetadata",
+    "inputs": [
+      {
+        "name": "store",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "deployedBlock",
+        "type": "uint128",
+        "internalType": "uint128"
+      },
+      {
+        "name": "lastUpdatedBlock",
+        "type": "uint128",
+        "internalType": "uint128"
+      },
+      {
+        "name": "description",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "pointer",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getStores",
+    "inputs": [
+      {
+        "name": "start",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "count",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address[]",
+        "internalType": "address[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getStoresReverse",
+    "inputs": [
+      {
+        "name": "start",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "count",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address[]",
+        "internalType": "address[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getUserDeletedStoreCount",
+    "inputs": [
+      {
+        "name": "user",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getUserDeletedStores",
+    "inputs": [
+      {
+        "name": "user",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address[]",
+        "internalType": "address[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getUserStoreCount",
+    "inputs": [
+      {
+        "name": "user",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getUserStores",
+    "inputs": [
+      {
+        "name": "user",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address[]",
+        "internalType": "address[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isActiveStore",
+    "inputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isDeleted",
+    "inputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isStoreDeleted",
+    "inputs": [
+      {
+        "name": "store",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isStoreLegit",
+    "inputs": [
+      {
+        "name": "store",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "nicknameVersion",
+    "inputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "owner",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "parameters",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "storeIndex",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "releaseNickname",
+    "inputs": [
+      {
+        "name": "nickname",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "renounceOwnership",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setPointer",
+    "inputs": [
+      {
+        "name": "store",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "pointer",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "storeMetadata",
+    "inputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "deployedBlock",
+        "type": "uint128",
+        "internalType": "uint128"
+      },
+      {
+        "name": "lastUpdatedBlock",
+        "type": "uint128",
+        "internalType": "uint128"
+      },
+      {
+        "name": "description",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "pointer",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "storeToNickname",
+    "inputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "transferOwnership",
+    "inputs": [
+      {
+        "name": "newOwner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateDescription",
+    "inputs": [
+      {
+        "name": "store",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "description",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateMetadata",
+    "inputs": [
+      {
+        "name": "store",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "description",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "pointer",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "userDeletedStores",
+    "inputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "userNicknameToStore",
+    "inputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "userStores",
+    "inputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "event",
+    "name": "MetadataUpdated",
+    "inputs": [
+      {
+        "name": "store",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "description",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      },
+      {
+        "name": "pointer",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      },
+      {
+        "name": "lastUpdatedBlock",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "NicknameReleased",
+    "inputs": [
+      {
+        "name": "user",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "store",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "nickname",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      },
+      {
+        "name": "version",
+        "type": "uint32",
+        "indexed": false,
+        "internalType": "uint32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipTransferred",
+    "inputs": [
+      {
+        "name": "previousOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "SensorStoreDeployed",
+    "inputs": [
+      {
+        "name": "creator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "store",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "nickname",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      },
+      {
+        "name": "initialAuthorizedSigners",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "storeType",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "OwnableInvalidOwner",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "OwnableUnauthorizedAccount",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  }
+]

--- a/src/abis/CatLabSensorStore.json
+++ b/src/abis/CatLabSensorStore.json
@@ -1,0 +1,633 @@
+[
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "_fields",
+        "type": "tuple[]",
+        "internalType": "struct CatLabSensorStore.Field[]",
+        "components": [
+          {
+            "name": "name",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "unit",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "dtype",
+            "type": "string",
+            "internalType": "string"
+          }
+        ]
+      },
+      {
+        "name": "_owner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_initialSigners",
+        "type": "address[]",
+        "internalType": "address[]"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "authorizeSigner",
+    "inputs": [
+      {
+        "name": "signer",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "authorizeSigners",
+    "inputs": [
+      {
+        "name": "signers",
+        "type": "address[]",
+        "internalType": "address[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "authorizedSignerCount",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "authorizedSigners",
+    "inputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "clearSignerData",
+    "inputs": [
+      {
+        "name": "signer",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "dataReadyFromBlock",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "fields",
+    "inputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "name",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "unit",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "dtype",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getAllFields",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple[]",
+        "internalType": "struct CatLabSensorStore.Field[]",
+        "components": [
+          {
+            "name": "name",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "unit",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "dtype",
+            "type": "string",
+            "internalType": "string"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getDataReadiness",
+    "inputs": [
+      {
+        "name": "blockNumber",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getField",
+    "inputs": [
+      {
+        "name": "index",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getLatestRecord",
+    "inputs": [
+      {
+        "name": "signer",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "",
+        "type": "int256[]",
+        "internalType": "int256[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getLatestRecordWithSigner",
+    "inputs": [
+      {
+        "name": "signer",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "",
+        "type": "int256[]",
+        "internalType": "int256[]"
+      },
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getTotalFields",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "hasData",
+    "inputs": [
+      {
+        "name": "signer",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "hasSignerData",
+    "inputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isDataReady",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isRecordReady",
+    "inputs": [
+      {
+        "name": "signer",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isSignerAuthorized",
+    "inputs": [
+      {
+        "name": "signer",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "lastDataTimestamp",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "latestRecord",
+    "inputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "timestamp",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "signer",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "owner",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "revokeSigner",
+    "inputs": [
+      {
+        "name": "signer",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "revokeSigners",
+    "inputs": [
+      {
+        "name": "signers",
+        "type": "address[]",
+        "internalType": "address[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "store",
+    "inputs": [
+      {
+        "name": "_values",
+        "type": "int256[]",
+        "internalType": "int256[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "storeWithAuthCheck",
+    "inputs": [
+      {
+        "name": "_values",
+        "type": "int256[]",
+        "internalType": "int256[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "storeWithTimestamp",
+    "inputs": [
+      {
+        "name": "_values",
+        "type": "int256[]",
+        "internalType": "int256[]"
+      },
+      {
+        "name": "_timestamp",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "storeWithTimestampAndAuthCheck",
+    "inputs": [
+      {
+        "name": "_values",
+        "type": "int256[]",
+        "internalType": "int256[]"
+      },
+      {
+        "name": "_timestamp",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateDataReadiness",
+    "inputs": [
+      {
+        "name": "_newReadyBlock",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "DataReadinessUpdated",
+    "inputs": [
+      {
+        "name": "newReadyBlock",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "previousBlock",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "FieldSchemaSet",
+    "inputs": [
+      {
+        "name": "count",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RecordStored",
+    "inputs": [
+      {
+        "name": "signer",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "timestamp",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "values",
+        "type": "int256[]",
+        "indexed": false,
+        "internalType": "int256[]"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "SignerAuthorized",
+    "inputs": [
+      {
+        "name": "signer",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "SignerRevoked",
+    "inputs": [
+      {
+        "name": "signer",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "UnauthorizedAccessAttempt",
+    "inputs": [
+      {
+        "name": "signer",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  }
+]

--- a/src/abis/README.md
+++ b/src/abis/README.md
@@ -1,0 +1,69 @@
+# Contract ABIs and Deployments
+
+This directory contains the Application Binary Interfaces (ABIs) for the Cat Lab IoT Factory smart contracts.
+
+## Files
+
+- `CatLabFactory.abi.json` - ABI for the factory contract that deploys sensor stores
+- `CatLabSensorStore.abi.json` - ABI for individual sensor store contracts
+- `deployments.json` - Deployment addresses and information for each network
+
+## Current Deployments
+
+### JIBCHAIN (Chain ID: 8899)
+
+#### CatLabFactory
+- **Address**: `0x63bB41b79b5aAc6e98C7b35Dcb0fE941b85Ba5Bb`
+- **Status**: Deployed (NOT verified)
+- **Owner**: `0xfD5203Fa21E0F8a1e45cda0dc6740B874fFF5909`
+
+#### CatLabSensorStore (Example)
+- **Address**: `0x887306B1EE95d20A6bC6f4390083d0bA2118f450`
+- **Status**: Deployed and Verified
+- **Owner**: `0x073caFeAD67E5bbD7537466C506976928ED8fF00`
+- **Explorer**: https://exp.jibchain.net/address/0x887306b1ee95d20a6bc6f4390083d0ba2118f450
+
+## Usage
+
+These ABIs can be used with web3 libraries like ethers.js or viem to interact with the deployed contracts.
+
+### Example with ethers.js:
+```javascript
+import { ethers } from 'ethers';
+import CatLabFactoryABI from './CatLabFactory.abi.json';
+import deployments from './deployments.json';
+
+const provider = new ethers.JsonRpcProvider(deployments.JIBCHAIN.rpcUrl);
+const factoryAddress = deployments.JIBCHAIN.contracts.CatLabFactory.address;
+const factory = new ethers.Contract(factoryAddress, CatLabFactoryABI, provider);
+```
+
+### Example with viem:
+```typescript
+import { createPublicClient, http } from 'viem';
+import { defineChain } from 'viem/chains';
+import CatLabFactoryABI from './CatLabFactory.abi.json';
+import deployments from './deployments.json';
+
+const jibchain = defineChain({
+  id: 8899,
+  name: 'JIBCHAIN',
+  network: 'jibchain',
+  nativeCurrency: { name: 'JBC', symbol: 'JBC', decimals: 18 },
+  rpcUrls: {
+    default: { http: ['https://rpc-l1.jbc.xpool.pw'] }
+  }
+});
+
+const publicClient = createPublicClient({
+  chain: jibchain,
+  transport: http()
+});
+
+// Read from factory
+const result = await publicClient.readContract({
+  address: deployments.JIBCHAIN.contracts.CatLabFactory.address,
+  abi: CatLabFactoryABI,
+  functionName: 'allStoresCount'
+});
+```

--- a/src/abis/deployments.json
+++ b/src/abis/deployments.json
@@ -1,0 +1,22 @@
+{
+  "JIBCHAIN": {
+    "chainId": 8899,
+    "rpcUrl": "https://rpc-l1.jbc.xpool.pw",
+    "explorer": "https://exp.jibchain.net",
+    "contracts": {
+      "CatLabFactory": {
+        "address": "0x63bB41b79b5aAc6e98C7b35Dcb0fE941b85Ba5Bb",
+        "deploymentBlock": 5940320,
+        "owner": "0xfD5203Fa21E0F8a1e45cda0dc6740B874fFF5909",
+        "verified": false
+      },
+      "CatLabSensorStore_Example": {
+        "address": "0x887306B1EE95d20A6bC6f4390083d0bA2118f450",
+        "deploymentBlock": null,
+        "owner": "0x073caFeAD67E5bbD7537466C506976928ED8fF00",
+        "verified": true,
+        "note": "This is a manually deployed example store, not from factory"
+      }
+    }
+  }
+}

--- a/src/abis/index.ts
+++ b/src/abis/index.ts
@@ -1,0 +1,4 @@
+// ABI exports for CatLab contracts
+export { default as CatLabFactoryABI } from './CatLabFactory.json';
+export { default as CatLabSensorStoreABI } from './CatLabSensorStore.json';
+export { default as deployments } from './deployments.json';

--- a/src/config/blockchain.config.ts
+++ b/src/config/blockchain.config.ts
@@ -26,7 +26,7 @@ export const BLOCKCHAIN_CONFIG: BlockchainConfig = {
   },
   8899: { // JIBCHAIN L1
     NAME: "JIBCHAIN L1",
-    DEPLOYER_ADDRESS: "0xd4673C5a2B2A01f7f335867271460733cA8a5C48", // Updated Factory (100 sensors)
+    DEPLOYER_ADDRESS: "0x63bB41b79b5aAc6e98C7b35Dcb0fE941b85Ba5Bb", // CatLabFactory (signer-based)
     EXPLORER_URL: "https://exp.jibchain.net",
   },
 };

--- a/src/pages/blockchain.astro
+++ b/src/pages/blockchain.astro
@@ -149,7 +149,7 @@ const configJson = JSON.stringify(BLOCKCHAIN_CONFIG);
       // Configuration injected at build time
       const CONTRACTS = JSON.parse(BLOCKCHAIN_CONFIG);
       
-      // Define ABIs
+      // Define ABIs with only the functions we need
       const DEPLOYER_ABI = [
         {
           "inputs": [
@@ -187,14 +187,38 @@ const configJson = JSON.stringify(BLOCKCHAIN_CONFIG);
         {
           "inputs": [],
           "name": "getAllFields",
-          "outputs": [{"components": [{"internalType": "string", "name": "name", "type": "string"}, {"internalType": "string", "name": "unit", "type": "string"}, {"internalType": "string", "name": "dtype", "type": "string"}], "internalType": "struct SecureSensorStore.Field[]", "name": "", "type": "tuple[]"}],
+          "outputs": [{"components": [{"internalType": "string", "name": "name", "type": "string"}, {"internalType": "string", "name": "unit", "type": "string"}, {"internalType": "string", "name": "dtype", "type": "string"}], "internalType": "struct CatLabSecureSensorStore.Field[]", "name": "", "type": "tuple[]"}],
           "stateMutability": "view",
           "type": "function"
         },
         {
           "inputs": [],
-          "name": "authorizedSensorCount",
+          "name": "authorizedSignerCount",
           "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "isDataReady",
+          "outputs": [{"internalType": "bool", "name": "", "type": "bool"}],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [{"internalType": "address", "name": "sensor", "type": "address"}],
+          "name": "hasData",
+          "outputs": [{"internalType": "bool", "name": "", "type": "bool"}],
+          "stateMutability": "view",
+          "type": "function"
+        },
+        {
+          "inputs": [{"internalType": "address", "name": "sensor", "type": "address"}],
+          "name": "getLatestRecord",
+          "outputs": [
+            {"internalType": "uint256", "name": "", "type": "uint256"},
+            {"internalType": "int256[]", "name": "", "type": "int256[]"}
+          ],
           "stateMutability": "view",
           "type": "function"
         }
@@ -352,17 +376,22 @@ const configJson = JSON.stringify(BLOCKCHAIN_CONFIG);
             className={`store-card relative rounded-xl overflow-hidden ${gradientClass} p-4 sm:p-6 text-white shadow-lg`}
             onClick={handleCardClick}
           >
-            {/* Status indicator */}
+            {/* Status indicator - now with 3 states */}
             <div className="absolute top-4 right-4">
-              {store.sensorCount > 0 ? (
+              {store.hasData ? (
                 <div className="flex items-center gap-1 bg-green-500/20 backdrop-blur px-2 py-1 rounded-full">
                   <span className="w-2 h-2 bg-green-400 rounded-full animate-pulse"></span>
-                  <span className="text-xs font-medium">Active</span>
+                  <span className="text-xs font-medium">Installed</span>
                 </div>
-              ) : (
+              ) : store.signerCount > 0 ? (
                 <div className="flex items-center gap-1 bg-yellow-500/20 backdrop-blur px-2 py-1 rounded-full">
                   <span className="w-2 h-2 bg-yellow-400 rounded-full"></span>
-                  <span className="text-xs font-medium">Pending</span>
+                  <span className="text-xs font-medium">Authorized</span>
+                </div>
+              ) : (
+                <div className="flex items-center gap-1 bg-gray-500/20 backdrop-blur px-2 py-1 rounded-full">
+                  <span className="w-2 h-2 bg-gray-400 rounded-full"></span>
+                  <span className="text-xs font-medium">Not Configured</span>
                 </div>
               )}
             </div>
@@ -380,7 +409,7 @@ const configJson = JSON.stringify(BLOCKCHAIN_CONFIG);
                 <span className="font-mono text-xs sm:text-sm break-all">{formatAddress(store.address)}</span>
                 <div className="flex flex-wrap gap-2 sm:gap-4">
                   <span>{store.fieldCount || 0} fields</span>
-                  <span>{store.sensorCount || 0} sensors</span>
+                  <span>{store.signerCount || 0} signers</span>
                 </div>
               </div>
               
@@ -525,23 +554,31 @@ const configJson = JSON.stringify(BLOCKCHAIN_CONFIG);
                 functionName: 'getAllFields'
               });
               
-              // Get sensor count from store
+              // Get signer count from store
               calls.push({
                 target: address,
                 abi: STORE_ABI,
-                functionName: 'authorizedSensorCount'
+                functionName: 'authorizedSignerCount'
+              });
+              
+              // Check if store has any data
+              calls.push({
+                target: address,
+                abi: STORE_ABI,
+                functionName: 'isDataReady'
               });
             });
             
             // Execute multicall
             const results = await simpleMulticall(publicClient, calls);
             
-            // Process results
+            // Process results - now with 4 results per store
             const processedStores = [];
             for (let i = 0; i < storeAddresses.length; i++) {
-              const infoResult = results[i * 3];
-              const fieldsResult = results[i * 3 + 1];
-              const sensorCountResult = results[i * 3 + 2];
+              const infoResult = results[i * 4];
+              const fieldsResult = results[i * 4 + 1];
+              const signerCountResult = results[i * 4 + 2];
+              const dataReadyResult = results[i * 4 + 3];
               
               processedStores.push({
                 address: storeAddresses[i],
@@ -550,7 +587,8 @@ const configJson = JSON.stringify(BLOCKCHAIN_CONFIG);
                 owner: infoResult.success ? infoResult.data[1] : null,
                 description: infoResult.success ? infoResult.data[4] : '',
                 fieldCount: fieldsResult.success ? fieldsResult.data.length : 0,
-                sensorCount: sensorCountResult.success ? Number(sensorCountResult.data) : 0,
+                signerCount: signerCountResult.success ? Number(signerCountResult.data) : 0,
+                hasData: dataReadyResult.success ? dataReadyResult.data : false,
                 deployedBlock: infoResult.success ? Number(infoResult.data[3]) : 0,
                 // Calculate the actual index in the factory array
                 // getStoresReverse returns from (total - offset - count) to (total - offset)
@@ -650,13 +688,27 @@ const configJson = JSON.stringify(BLOCKCHAIN_CONFIG);
               <LoadingSkeleton />
             ) : stores.length > 0 ? (
               <>
-                {/* Group stores by installation status */}
+                {/* Group stores by installation status - now with 3 states */}
                 {(() => {
-                  // For now, use authorized sensor count as a proxy
-                  // Stores with 0 sensors are definitely not installed
-                  // This is a temporary solution until we implement proper data checking
-                  const installedStores = stores.filter(s => s.sensorCount > 0);
-                  const beingInstalledStores = stores.filter(s => s.sensorCount === 0);
+                  // Use hasData flag for accurate detection
+                  const installedStores = stores.filter(s => s.hasData);
+                  const authorizedStores = stores.filter(s => s.signerCount > 0 && !s.hasData);
+                  const notConfiguredStores = stores.filter(s => s.signerCount === 0);
+                  
+                  // Sort all groups by nickname (ascending: FloodBoy001, FloodBoy002, etc.)
+                  const sortByNickname = (a, b) => {
+                    // Extract number from nickname (e.g., "FloodBoy080" -> 80)
+                    const getNumber = (store) => {
+                      if (!store.nickname || store.nickname === 'Unknown') return 999999;
+                      const match = store.nickname.match(/FloodBoy(\d+)/);
+                      return match ? parseInt(match[1], 10) : 999999;
+                    };
+                    return getNumber(a) - getNumber(b);
+                  };
+                  
+                  installedStores.sort(sortByNickname);
+                  authorizedStores.sort(sortByNickname);
+                  notConfiguredStores.sort(sortByNickname);
                   
                   return (
                     <>
@@ -675,16 +727,31 @@ const configJson = JSON.stringify(BLOCKCHAIN_CONFIG);
                         </div>
                       )}
                       
-                      {/* Being Installed Section */}
-                      {beingInstalledStores.length > 0 && (
-                        <div>
+                      {/* Authorized but No Data Section */}
+                      {authorizedStores.length > 0 && (
+                        <div className="mb-8">
                           <h2 className="text-xl font-bold mb-4 flex items-center gap-2">
                             <span className="w-3 h-3 bg-yellow-500 rounded-full"></span>
-                            Being Installed ({beingInstalledStores.length})
+                            Authorized ({authorizedStores.length})
                           </h2>
                           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-6 lg:grid-cols-3">
-                            {beingInstalledStores.map((store, index) => (
+                            {authorizedStores.map((store, index) => (
                               <StoreCard key={store.address} store={store} index={installedStores.length + index} />
+                            ))}
+                          </div>
+                        </div>
+                      )}
+                      
+                      {/* Not Configured Section */}
+                      {notConfiguredStores.length > 0 && (
+                        <div>
+                          <h2 className="text-xl font-bold mb-4 flex items-center gap-2">
+                            <span className="w-3 h-3 bg-gray-500 rounded-full"></span>
+                            Not Configured ({notConfiguredStores.length})
+                          </h2>
+                          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-6 lg:grid-cols-3">
+                            {notConfiguredStores.map((store, index) => (
+                              <StoreCard key={store.address} store={store} index={installedStores.length + authorizedStores.length + index} />
                             ))}
                           </div>
                         </div>

--- a/src/pages/blockchain.astro
+++ b/src/pages/blockchain.astro
@@ -200,8 +200,8 @@ const configJson = JSON.stringify(BLOCKCHAIN_CONFIG);
         },
         {
           "inputs": [],
-          "name": "isDataReady",
-          "outputs": [{"internalType": "bool", "name": "", "type": "bool"}],
+          "name": "lastDataTimestamp",
+          "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
           "stateMutability": "view",
           "type": "function"
         },
@@ -561,11 +561,11 @@ const configJson = JSON.stringify(BLOCKCHAIN_CONFIG);
                 functionName: 'authorizedSignerCount'
               });
               
-              // Check if store has any data
+              // Get last data timestamp (0 = no data)
               calls.push({
                 target: address,
                 abi: STORE_ABI,
-                functionName: 'isDataReady'
+                functionName: 'lastDataTimestamp'
               });
             });
             
@@ -578,7 +578,9 @@ const configJson = JSON.stringify(BLOCKCHAIN_CONFIG);
               const infoResult = results[i * 4];
               const fieldsResult = results[i * 4 + 1];
               const signerCountResult = results[i * 4 + 2];
-              const dataReadyResult = results[i * 4 + 3];
+              const timestampResult = results[i * 4 + 3];
+              
+              const lastDataTimestamp = timestampResult.success ? Number(timestampResult.data) : 0;
               
               processedStores.push({
                 address: storeAddresses[i],
@@ -588,7 +590,8 @@ const configJson = JSON.stringify(BLOCKCHAIN_CONFIG);
                 description: infoResult.success ? infoResult.data[4] : '',
                 fieldCount: fieldsResult.success ? fieldsResult.data.length : 0,
                 signerCount: signerCountResult.success ? Number(signerCountResult.data) : 0,
-                hasData: dataReadyResult.success ? dataReadyResult.data : false,
+                hasData: lastDataTimestamp > 0,
+                lastDataTimestamp,
                 deployedBlock: infoResult.success ? Number(infoResult.data[3]) : 0,
                 // Calculate the actual index in the factory array
                 // getStoresReverse returns from (total - offset - count) to (total - offset)


### PR DESCRIPTION
## Summary
- Implements accurate sensor installation detection using `lastDataTimestamp` field
- Updates from sensor to signer terminology throughout
- Provides three-state categorization for better UX

## Changes
1. **Updated detection method**: 
   - Changed from `isDataReady()` to `lastDataTimestamp` public variable
   - Stores with `timestamp > 0` are considered installed
   - More accurate than just checking authorized signer count

2. **Three-state UI categorization**:
   - **Installed** (Green, pulsing): Stores with actual data (`lastDataTimestamp > 0`)
   - **Authorized** (Yellow): Stores with signers but no data yet
   - **Not Configured** (Gray): Stores with no signers authorized

3. **Factory address update**:
   - Updated to CatLab factory: `0x63bB41b79b5aAc6e98C7b35Dcb0fE941b85Ba5Bb`
   - Uses signer-based terminology throughout

## Test Results
Verified with cast commands:
- FloodBoy001: timestamp = 1753148999 (HAS DATA) ✅
- FloodBoy002: timestamp = 1753149119 (HAS DATA) ✅  
- FloodBoy003: timestamp = 0 (NO DATA) ✅
- FloodBoy004: timestamp = 0 (NO DATA) ✅
- FloodBoy005: timestamp = 0 (NO DATA) ✅

## Fixes #73

🤖 Generated with [Claude Code](https://claude.ai/code)