### PR TITLE
feat: Add multiple time interval grouping for charts with smart defaults

### DIFF
--- a/src/pages/blockchain/[address].astro
+++ b/src/pages/blockchain/[address].astro
@@ -842,8 +842,8 @@ const pageTitle = aliasInfo
 				const [showAllRecords, setShowAllRecords] = React.useState(false);
 				const [recordsLimit, setRecordsLimit] = React.useState(10); // Default to 10 records
 				const [selectedFields, setSelectedFields] = React.useState(['water_depth']); // Default to water depth only
-				const [startFromZero, setStartFromZero] = React.useState(true); // Default to start from 0
-				const [groupingInterval, setGroupingInterval] = React.useState('none'); // 'none', '15min', '30min', '1hr', '3hr', '6hr'
+				const [startFromZero, setStartFromZero] = React.useState(false); // Default to relative scale
+				const [groupingInterval, setGroupingInterval] = React.useState('30min'); // Default to 30 minute grouping
 
 				// Aggregate data by time intervals
 				const aggregateDataByInterval = React.useCallback((records, interval) => {
@@ -1326,8 +1326,21 @@ const pageTitle = aliasInfo
 							// Only update sensor records if they actually changed
 							setSensorRecords(prevRecords => {
 								// Check if records are different
-								if (prevRecords.length !== allRecords.length || 
-									JSON.stringify(prevRecords) !== JSON.stringify(allRecords)) {
+								if (prevRecords.length !== allRecords.length) {
+									return allRecords;
+								}
+								
+								// Deep comparison without JSON.stringify to handle BigInt
+								const hasChanged = prevRecords.some((record, index) => {
+									const newRecord = allRecords[index];
+									return record.timestamp !== newRecord.timestamp ||
+										   record.sensor !== newRecord.sensor ||
+										   record.transactionHash !== newRecord.transactionHash ||
+										   record.blockNumber !== newRecord.blockNumber ||
+										   record.values.some((val, i) => val !== newRecord.values[i]);
+								});
+								
+								if (hasChanged) {
 									return allRecords;
 								}
 								return prevRecords; // Keep the same reference to avoid re-render
@@ -1941,24 +1954,26 @@ const pageTitle = aliasInfo
 								},
 									React.createElement('div', { className: 'flex items-center justify-between mb-4' },
 									React.createElement('div', {},
-										React.createElement('h3', { className: 'text-lg font-semibold flex items-center gap-2' }, 
-											'Sensor Data Records',
-											sensorRecords.length > 0 && React.createElement('span', { 
-												className: 'text-xs px-2 py-1 bg-blue-100 text-blue-700 rounded-full font-normal' 
-											}, `${sensorRecords.length} total`),
-											activeTab === 'chart' && groupingInterval !== 'none' && sensorRecords.length > 0 && React.createElement('span', { 
-												className: 'text-xs px-2 py-1 bg-amber-100 text-amber-700 rounded-full font-normal' 
-											}, `→ ${(() => {
-												const grouped = aggregateDataByInterval([...sensorRecords].sort((a, b) => a.timestamp - b.timestamp), groupingInterval);
-												return `${grouped.length} grouped`;
-											})()}`),
-											currentChain === 8899 && blockNumber && React.createElement('span', { 
-												className: 'flex items-center gap-1 text-xs px-2 py-1 bg-green-100 text-green-700 rounded-full font-normal' 
-											},
-												React.createElement('span', { 
-													className: 'inline-block w-2 h-2 bg-green-500 rounded-full animate-pulse' 
-												}),
-												'Live'
+										React.createElement('h3', { className: 'text-lg font-semibold flex items-center flex-wrap gap-2' }, 
+											React.createElement('span', {}, 'Sensor Data Records'),
+											React.createElement('div', { className: 'flex items-center gap-2' },
+												sensorRecords.length > 0 && React.createElement('span', { 
+													className: 'text-xs px-2 py-1 bg-blue-100 text-blue-700 rounded-full font-normal whitespace-nowrap' 
+												}, `${sensorRecords.length} total`),
+												activeTab === 'chart' && groupingInterval !== 'none' && sensorRecords.length > 0 && React.createElement('span', { 
+													className: 'text-xs px-2 py-1 bg-amber-100 text-amber-700 rounded-full font-normal whitespace-nowrap' 
+												}, `→ ${(() => {
+													const grouped = aggregateDataByInterval([...sensorRecords].sort((a, b) => a.timestamp - b.timestamp), groupingInterval);
+													return `${grouped.length} grouped`;
+												})()}`),
+												currentChain === 8899 && blockNumber && React.createElement('span', { 
+													className: 'inline-flex items-center gap-1 text-xs px-2 py-1 bg-green-100 text-green-700 rounded-full font-normal whitespace-nowrap' 
+												},
+													React.createElement('span', { 
+														className: 'inline-block w-2 h-2 bg-green-500 rounded-full animate-pulse' 
+													}),
+													'Live'
+												)
 											)
 										),
 										React.createElement('p', { className: 'text-sm text-gray-600 flex items-center gap-2' }, 

--- a/src/pages/blockchain/[address].astro
+++ b/src/pages/blockchain/[address].astro
@@ -843,6 +843,108 @@ const pageTitle = aliasInfo
 				const [recordsLimit, setRecordsLimit] = React.useState(10); // Default to 10 records
 				const [selectedFields, setSelectedFields] = React.useState(['water_depth']); // Default to water depth only
 				const [startFromZero, setStartFromZero] = React.useState(true); // Default to start from 0
+				const [groupingInterval, setGroupingInterval] = React.useState('none'); // 'none', '15min', '30min', '1hr', '3hr', '6hr'
+
+				// Aggregate data by time intervals
+				const aggregateDataByInterval = React.useCallback((records, interval) => {
+					if (!records || records.length === 0 || interval === 'none') return records;
+					
+					// Helper to round timestamp down to nearest interval boundary
+					const roundToInterval = (timestamp) => {
+						const date = new Date(timestamp * 1000);
+						date.setSeconds(0);
+						date.setMilliseconds(0);
+						
+						switch (interval) {
+							case '15min':
+								const minutes15 = Math.floor(date.getMinutes() / 15) * 15;
+								date.setMinutes(minutes15);
+								break;
+							case '30min':
+								const minutes30 = Math.floor(date.getMinutes() / 30) * 30;
+								date.setMinutes(minutes30);
+								break;
+							case '1hr':
+								date.setMinutes(0);
+								break;
+							case '3hr':
+								date.setMinutes(0);
+								const hours3 = Math.floor(date.getHours() / 3) * 3;
+								date.setHours(hours3);
+								break;
+							case '6hr':
+								date.setMinutes(0);
+								const hours6 = Math.floor(date.getHours() / 6) * 6;
+								date.setHours(hours6);
+								break;
+							default:
+								return timestamp;
+						}
+						
+						return Math.floor(date.getTime() / 1000);
+					};
+					
+					// Group records by time windows
+					const groups = {};
+					records.forEach(record => {
+						const windowStart = roundToInterval(record.timestamp);
+						if (!groups[windowStart]) {
+							groups[windowStart] = [];
+						}
+						groups[windowStart].push(record);
+					});
+					
+					// Aggregate each group
+					const aggregatedRecords = Object.entries(groups).map(([windowStart, windowRecords]) => {
+						const timestamp = parseInt(windowStart);
+						
+						// For each field, apply appropriate aggregation
+						const aggregatedValues = storeData.fields.map((field, fieldIndex) => {
+							const values = windowRecords
+								.map(r => r.values[fieldIndex])
+								.filter(v => v !== null && v !== undefined);
+							
+							if (values.length === 0) return null;
+							
+							// Apply field-specific aggregation strategy
+							if (field.name.endsWith('_min')) {
+								// For min fields, take the minimum
+								return Math.min(...values);
+							} else if (field.name.endsWith('_max')) {
+								// For max fields, take the maximum
+								return Math.max(...values);
+							} else if (field.name.endsWith('_count')) {
+								// For count fields, sum them
+								return values.reduce((sum, val) => sum + val, 0);
+							} else if (field.name === 'installation_height') {
+								// Installation height is typically constant, take the first value
+								return values[0];
+							} else {
+								// For regular fields (water_depth, battery_voltage, etc.), take average
+								const sum = values.reduce((acc, val) => acc + val, 0);
+								return sum / values.length;
+							}
+						});
+						
+						// Use the first record's metadata as representative
+						const representativeRecord = windowRecords[0];
+						
+						return {
+							sensor: representativeRecord.sensor,
+							timestamp: timestamp,
+							values: aggregatedValues,
+							blockNumber: windowRecords[windowRecords.length - 1].blockNumber, // Last block in window
+							transactionHash: representativeRecord.transactionHash,
+							// Add metadata about aggregation
+							aggregated: true,
+							recordCount: windowRecords.length,
+							originalTimestamps: windowRecords.map(r => r.timestamp)
+						};
+					});
+					
+					// Sort by timestamp ascending (for chart display)
+					return aggregatedRecords.sort((a, b) => a.timestamp - b.timestamp);
+				}, [storeData]);
 
 				// Create chart function
 				const createChart = React.useCallback(() => {
@@ -859,9 +961,27 @@ const pageTitle = aliasInfo
 					
 					// Prepare data for chart
 					const sortedRecords = [...sensorRecords].sort((a, b) => a.timestamp - b.timestamp);
-					const labels = sortedRecords.map(record => 
-						new Date(record.timestamp * 1000).toLocaleString()
-					);
+					
+					// Apply time interval grouping if enabled
+					const processedRecords = groupingInterval !== 'none' ? 
+						aggregateDataByInterval(sortedRecords, groupingInterval) : 
+						sortedRecords;
+					
+					// Format labels based on grouping mode
+					const labels = processedRecords.map(record => {
+						const date = new Date(record.timestamp * 1000);
+						if (groupingInterval !== 'none') {
+							// For grouped data, show cleaner time format
+							return date.toLocaleString('en-US', {
+								month: 'short',
+								day: 'numeric',
+								hour: '2-digit',
+								minute: '2-digit',
+								hour12: false
+							});
+						}
+						return date.toLocaleString();
+					});
 
 					// Create datasets - show only selected fields
 					const datasets = storeData.fields
@@ -881,7 +1001,7 @@ const pageTitle = aliasInfo
 							};
 							const color = colors[field.name] || colors['water_depth'];
 							
-							const data = sortedRecords.map(record => {
+							const data = processedRecords.map(record => {
 								if (record.values[fieldIndex] !== undefined) {
 									return parseFloat(formatScaledValue(record.values[fieldIndex], field.unit));
 								}
@@ -928,9 +1048,9 @@ const pageTitle = aliasInfo
 							plugins: {
 								title: {
 									display: true,
-									text: selectedFields.length === 1 && selectedFields[0] === 'water_depth' 
+									text: (selectedFields.length === 1 && selectedFields[0] === 'water_depth' 
 										? 'Water Depth Over Time' 
-										: 'Sensor Data Over Time',
+										: 'Sensor Data Over Time') + (groupingInterval !== 'none' ? ` (${groupingInterval} avg)` : ''),
 									font: {
 										size: 16,
 										weight: '600'
@@ -939,6 +1059,20 @@ const pageTitle = aliasInfo
 								legend: {
 									display: true,
 									position: 'top'
+								},
+								tooltip: {
+									callbacks: {
+										afterLabel: function(context) {
+											// Show aggregation info in tooltip when grouping is enabled
+											if (groupingInterval !== 'none' && processedRecords[context.dataIndex]) {
+												const record = processedRecords[context.dataIndex];
+												if (record.aggregated && record.recordCount) {
+													return `Aggregated from ${record.recordCount} records`;
+												}
+											}
+											return '';
+										}
+									}
 								}
 							},
 							scales: {
@@ -973,7 +1107,7 @@ const pageTitle = aliasInfo
 							}
 						}
 					});
-				}, [sensorRecords, storeData, selectedFields, startFromZero]);
+				}, [sensorRecords, storeData, selectedFields, startFromZero, groupingInterval, aggregateDataByInterval]);
 
 				// Update chart when data changes
 				React.useEffect(() => {
@@ -991,7 +1125,7 @@ const pageTitle = aliasInfo
 							chartInstanceRef.current = null;
 						}
 					};
-				}, [activeTab, sensorRecords, selectedFields, createChart, startFromZero]);
+				}, [activeTab, sensorRecords, selectedFields, createChart, startFromZero, groupingInterval]);
 
 				// Define loadEnhancedStoreData function
 				const loadEnhancedStoreData = React.useCallback(async () => {
@@ -1812,6 +1946,12 @@ const pageTitle = aliasInfo
 											sensorRecords.length > 0 && React.createElement('span', { 
 												className: 'text-xs px-2 py-1 bg-blue-100 text-blue-700 rounded-full font-normal' 
 											}, `${sensorRecords.length} total`),
+											activeTab === 'chart' && groupingInterval !== 'none' && sensorRecords.length > 0 && React.createElement('span', { 
+												className: 'text-xs px-2 py-1 bg-amber-100 text-amber-700 rounded-full font-normal' 
+											}, `→ ${(() => {
+												const grouped = aggregateDataByInterval([...sensorRecords].sort((a, b) => a.timestamp - b.timestamp), groupingInterval);
+												return `${grouped.length} grouped`;
+											})()}`),
 											currentChain === 8899 && blockNumber && React.createElement('span', { 
 												className: 'flex items-center gap-1 text-xs px-2 py-1 bg-green-100 text-green-700 rounded-full font-normal' 
 											},
@@ -2023,8 +2163,8 @@ const pageTitle = aliasInfo
 											)
 										)
 									),
-									// Scale toggle
-									React.createElement('div', { className: 'flex items-center gap-2' },
+									// Scale and grouping toggles
+									React.createElement('div', { className: 'flex items-center gap-4' },
 										React.createElement('label', { className: 'flex items-center gap-2 cursor-pointer' },
 											React.createElement('input', {
 												type: 'checkbox',
@@ -2034,6 +2174,23 @@ const pageTitle = aliasInfo
 											}),
 											React.createElement('span', { className: 'text-sm font-medium text-gray-700' }, 
 												'Start Y-axis from 0'
+											)
+										),
+										React.createElement('div', { className: 'flex items-center gap-2' },
+											React.createElement('label', { className: 'text-sm font-medium text-gray-700' }, 
+												'Group data:'
+											),
+											React.createElement('select', {
+												value: groupingInterval,
+												onChange: (e) => setGroupingInterval(e.target.value),
+												className: 'text-sm border border-gray-300 rounded px-2 py-1 focus:outline-none focus:ring-2 focus:ring-blue-500'
+											},
+												React.createElement('option', { value: 'none' }, 'None'),
+												React.createElement('option', { value: '15min' }, '15 minutes'),
+												React.createElement('option', { value: '30min' }, '30 minutes'),
+												React.createElement('option', { value: '1hr' }, '1 hour'),
+												React.createElement('option', { value: '3hr' }, '3 hours'),
+												React.createElement('option', { value: '6hr' }, '6 hours')
 											)
 										)
 									)


### PR DESCRIPTION
## Summary
- Implemented flexible time interval grouping for sensor data charts
- Added support for 15min, 30min, 1hr, 3hr, and 6hr aggregation
- Fixed BigInt serialization error and UI layout issues

## Changes Made

### 1. Time Interval Grouping
- Replaced boolean grouping toggle with dropdown selector
- Options: None, 15 minutes, 30 minutes, 1 hour, 3 hours, 6 hours
- Smart aggregation based on field type:
  - Regular fields (water_depth, battery_voltage): Average
  - Min/max fields: Actual min/max from period
  - Count fields: Sum
  - Installation height: First value (typically constant)

### 2. Default Settings
- Changed default Y-axis to relative scale (not starting from 0)
- Changed default grouping interval to 30 minutes
- Better visualization for typical sensor data patterns

### 3. UI Enhancements
- Chart title shows selected interval (e.g., "Water Depth Over Time (30min avg)")
- Badge layout properly handles grouped data indicator
- Tooltips show number of records aggregated per data point
- Visual indicator: "204 total → 17 grouped"

### 4. Bug Fixes
- Fixed BigInt serialization error on refresh
- Fixed badge wrapping that created oval shapes
- Improved flex layout for responsive design

## Test Plan
- [x] Build passes without errors
- [x] All time intervals group data correctly
- [x] Chart updates immediately when changing interval
- [x] Refresh no longer causes BigInt errors
- [x] UI badges display properly without wrapping issues

Implements #90