### PR TITLE
Add resilient RPC selection with fallback support

### DIFF
--- a/src/utils/blockchain-constants.ts
+++ b/src/utils/blockchain-constants.ts
@@ -1,6 +1,13 @@
 // Blockchain network configurations and contract constants
 import { BLOCKCHAIN_CONFIG } from '../config/blockchain.config';
 
+export const JIBCHAIN_RPC_ENDPOINTS = [
+  'https://rpc-l1.inan.in.th',
+  'https://rpc2-l1.jbc.xpool.pw',
+  'https://rpc-l1.jbc.xpool.pw',
+  'https://rpc-l1.jibchain.net',
+] as const;
+
 // Universal Multicall3 address (same on all chains)
 export const MULTICALL3_ADDRESS = "0xcA11bde05977b3631167028862bE2a173976CA11" as const;
 
@@ -149,8 +156,8 @@ export const jibchainL1 = {
   network: 'jibchain',
   nativeCurrency: { name: 'JBC', symbol: 'JBC', decimals: 18 },
   rpcUrls: {
-    default: { http: ['https://rpc-l1.jibchain.net'] },
-    public: { http: ['https://rpc-l1.jibchain.net'] }
+    default: { http: [...JIBCHAIN_RPC_ENDPOINTS] },
+    public: { http: [...JIBCHAIN_RPC_ENDPOINTS] }
   },
   blockExplorers: {
     default: { name: 'JBC Explorer', url: 'https://exp.jibchain.net' }

--- a/src/utils/rpc.ts
+++ b/src/utils/rpc.ts
@@ -1,0 +1,144 @@
+import { createPublicClient, fallback, http, type Chain, type PublicClient, type Transport } from 'viem';
+import { SUPPORTED_CHAINS } from './blockchain-constants';
+
+const RPC_HEALTH_TIMEOUT = 4_000;
+const RPC_CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+
+interface RpcHealthResult {
+  url: string;
+  latency: number;
+}
+
+interface RpcCacheEntry {
+  urls: string[];
+  timestamp: number;
+}
+
+export interface ResilientClientResult {
+  client: PublicClient;
+  rpcUrls: string[];
+  primaryRpcUrl: string;
+}
+
+const rpcOrderCache = new Map<number, RpcCacheEntry>();
+
+function getChain(chainId: number): Chain | undefined {
+  return SUPPORTED_CHAINS.find((chain) => chain.id === chainId);
+}
+
+async function measureRpcLatency(url: string): Promise<RpcHealthResult> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), RPC_HEALTH_TIMEOUT);
+
+  try {
+    const start = Date.now();
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: Math.floor(Math.random() * 1_000_000),
+        method: 'eth_blockNumber',
+        params: [],
+      }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      throw new Error(`RPC ${url} responded with status ${response.status}`);
+    }
+
+    const data = await response.json();
+    if (typeof data.result === 'string') {
+      return { url, latency: Date.now() - start };
+    }
+
+    throw new Error(`RPC ${url} returned unexpected payload`);
+  } catch (error) {
+    console.warn('[rpc] RPC latency check failed', url, error);
+    return { url, latency: Number.POSITIVE_INFINITY };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function rankRpcUrls(chainId: number, urls: readonly string[]): Promise<string[]> {
+  if (urls.length <= 1) {
+    return [...urls];
+  }
+
+  const cached = rpcOrderCache.get(chainId);
+  if (cached && Date.now() - cached.timestamp < RPC_CACHE_TTL && cached.urls.every((url) => urls.includes(url))) {
+    return cached.urls;
+  }
+
+  const results = await Promise.all(urls.map((url) => measureRpcLatency(url)));
+  const healthy = results.filter((result) => Number.isFinite(result.latency));
+  const unhealthy = results.filter((result) => !Number.isFinite(result.latency));
+
+  const ordered = [
+    ...healthy.sort((a, b) => a.latency - b.latency),
+    ...unhealthy,
+  ].map((result) => result.url);
+
+  rpcOrderCache.set(chainId, { urls: ordered, timestamp: Date.now() });
+
+  return ordered;
+}
+
+function buildTransport(urls: string[]): Transport | null {
+  if (!urls.length) {
+    return null;
+  }
+
+  const transports = urls.map((url) =>
+    http(url, {
+      retryCount: 2,
+      timeout: RPC_HEALTH_TIMEOUT,
+    })
+  );
+
+  if (transports.length === 1) {
+    return transports[0];
+  }
+
+  return fallback(transports);
+}
+
+export async function createResilientPublicClient(chainId: number): Promise<ResilientClientResult | null> {
+  const chain = getChain(chainId);
+  if (!chain) {
+    console.error(`[rpc] Unsupported chainId ${chainId}`);
+    return null;
+  }
+
+  const baseUrls = chain.rpcUrls?.default?.http ?? [];
+  if (!baseUrls.length) {
+    console.error(`[rpc] No RPC URLs configured for chainId ${chainId}`);
+    return null;
+  }
+
+  const rankedUrls = chainId === 8899 ? await rankRpcUrls(chainId, baseUrls) : [...baseUrls];
+  const transport = buildTransport(rankedUrls);
+
+  if (!transport) {
+    console.error('[rpc] Failed to build RPC transport');
+    return null;
+  }
+
+  const client = createPublicClient({
+    chain,
+    transport,
+  });
+
+  const primaryRpcUrl = rankedUrls[0];
+  rpcOrderCache.set(chainId, { urls: rankedUrls, timestamp: Date.now() });
+
+  return {
+    client,
+    rpcUrls: rankedUrls,
+    primaryRpcUrl,
+  };
+}


### PR DESCRIPTION
## Summary
- add a shared RPC utility that measures latency, caches rankings, and builds viem fallback transports for JIBCHAIN
- expose the complete RPC endpoint list in blockchain constants and consume the resilient client in the nanostore
- update the dashboard to reuse the resilient client, track active store state safely, and refresh data without re-creating clients on each render

## Testing
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8f73c678c8328a51b06fb46057c26