### PR TITLE
Show active RPC endpoint on blockchain store loading screen

### DIFF
--- a/src/pages/blockchain/[address].astro
+++ b/src/pages/blockchain/[address].astro
@@ -892,11 +892,31 @@ const pageTitle = aliasInfo
 			}
 
 			// Main BlockchainApp Component
-			function BlockchainApp() {
-				const [currentChain, setCurrentChain] = React.useState(8899);
-				const [storeData, setStoreData] = React.useState(null);
-				const [isLoading, setIsLoading] = React.useState(true);
-				const [isRefreshing, setIsRefreshing] = React.useState(false);
+                        function BlockchainApp() {
+                                function getChainConfigForId(chainId) {
+                                        switch (chainId) {
+                                                case 8899:
+                                                        return window.chains.jibchainL1;
+                                                case 700011:
+                                                        return window.chains.sichang;
+                                                case 31337:
+                                                        return window.chains.anvil;
+                                                default:
+                                                        return window.chains.jibchainL1;
+                                        }
+                                }
+
+                                function getRpcUrlForChain(chainId) {
+                                        const chainConfig = getChainConfigForId(chainId);
+                                        const urls = chainConfig?.rpcUrls?.default?.http || [];
+                                        return urls.length > 0 ? urls[0] : null;
+                                }
+
+                                const [currentChain, setCurrentChain] = React.useState(8899);
+                                const [storeData, setStoreData] = React.useState(null);
+                                const [isLoading, setIsLoading] = React.useState(true);
+                                const [isRefreshing, setIsRefreshing] = React.useState(false);
+                                const [activeRpcUrl, setActiveRpcUrl] = React.useState(() => getRpcUrlForChain(8899));
 				
 				// Helper function to format address
 				const formatAddress = (address) => {
@@ -1260,12 +1280,18 @@ const pageTitle = aliasInfo
 						}
 						setError(null);
 						
-						try {
-							// Create public client for JIBCHAIN L1
-							const publicClient = window.viem.createPublicClient({
-								chain: window.chains.jibchainL1,
-								transport: window.viem.http()
-							});
+                                                try {
+                                                        const chainConfig = getChainConfigForId(currentChain);
+                                                        const rpcUrl = getRpcUrlForChain(currentChain);
+
+                                                        if (rpcUrl) {
+                                                                setActiveRpcUrl(rpcUrl);
+                                                        }
+
+                                                        const publicClient = window.viem.createPublicClient({
+                                                                chain: chainConfig,
+                                                                transport: rpcUrl ? window.viem.http(rpcUrl) : window.viem.http()
+                                                        });
 
 							console.log('Loading enhanced data for store:', storeAddress);
 
@@ -1654,11 +1680,18 @@ const pageTitle = aliasInfo
 				React.useEffect(() => {
 					let unwatch;
 					
-					if (currentChain === 8899) {
-						const publicClient = window.viem.createPublicClient({
-							chain: window.chains.jibchainL1,
-							transport: window.viem.http()
-						});
+                                        if (currentChain === 8899) {
+                                                const chainConfig = getChainConfigForId(currentChain);
+                                                const rpcUrl = getRpcUrlForChain(currentChain);
+
+                                                if (rpcUrl) {
+                                                        setActiveRpcUrl(rpcUrl);
+                                                }
+
+                                                const publicClient = window.viem.createPublicClient({
+                                                        chain: chainConfig,
+                                                        transport: rpcUrl ? window.viem.http(rpcUrl) : window.viem.http()
+                                                });
 						
 						// Use viem's watchBlocks for efficient block monitoring
 						unwatch = publicClient.watchBlocks({
@@ -1766,11 +1799,12 @@ const pageTitle = aliasInfo
 				// Only show loading spinner on initial load when no data exists
 				if (isLoading && !storeData) {
 					return React.createElement('div', { className: 'container mx-auto p-4 sm:p-6' },
-						React.createElement('div', { className: 'text-center' },
-							React.createElement('div', { className: 'animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4' }),
-							React.createElement('p', { className: 'text-gray-600' }, 'Loading blockchain data...'),
-							React.createElement('p', { className: 'text-gray-500 text-sm mt-2 font-mono' }, storeAddress)
-						)
+                                                React.createElement('div', { className: 'text-center' },
+                                                        React.createElement('div', { className: 'animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4' }),
+                                                        React.createElement('p', { className: 'text-gray-600' }, 'Loading blockchain data...'),
+                                                        React.createElement('p', { className: 'text-gray-500 text-xs mt-2 font-mono' }, activeRpcUrl ? `RPC: ${activeRpcUrl}` : 'RPC: selecting optimal endpoint...'),
+                                                        React.createElement('p', { className: 'text-gray-500 text-sm mt-2 font-mono' }, storeAddress)
+                                                )
 					);
 				}
 


### PR DESCRIPTION
## Summary
- derive the active RPC URL for each chain and track it in component state
- use the derived RPC URL when creating viem clients so the selected endpoint is explicit
- surface the active RPC on the loading screen to show which endpoint is in use

## Testing
- pnpm dev --host 0.0.0.0 --port 4321

------
https://chatgpt.com/codex/tasks/task_e_68d9216c900c832898bc8167c2d8c2cc