### PR TITLE
Prioritize Inan RPC endpoint for blockchain page

### DIFF
--- a/src/pages/blockchain/[address].astro
+++ b/src/pages/blockchain/[address].astro
@@ -310,9 +310,9 @@ const pageTitle = aliasInfo
 			
 			// Custom chain configurations
                         const prioritizedJibchainRpcUrls = [
+                                'https://rpc-l1.inan.in.th',
                                 'https://rpc2-l1.jbc.xpool.pw',
                                 'https://rpc-l1.jbc.xpool.pw',
-                                'https://rpc-l1.inan.in.th',
                                 'https://rpc-l1.jibchain.net'
                         ];
 


### PR DESCRIPTION
## Summary
- reorder the blockchain page RPC priority so the Inan endpoint is tried first for faster initial loads

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da67caad908328b70f6c7bfafa8a23