### PR TITLE
Move main site banner into blockchain page intro

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -4,16 +4,18 @@ const currentPath = Astro.url.pathname;
 ---
 
 <header>
-	<nav>
-		<a href="/" class="logo">
-			<img src="/floodboy-logo.png" alt="Floodboy" />
-			<span>FloodBoy: IoT-Powered Blockchain</span>
-		</a>
-		<button class="mobile-menu-toggle" aria-label="Toggle menu">
-			<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-				<path d="M3 12h18M3 6h18M3 18h18"></path>
-			</svg>
-		</button>
+        <nav>
+                <div class="branding">
+                        <a href="/" class="logo">
+                                <img src="/floodboy-logo.png" alt="Floodboy" />
+                                <span>FloodBoy: IoT-Powered Blockchain</span>
+                        </a>
+                </div>
+                <button class="mobile-menu-toggle" aria-label="Toggle menu">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <path d="M3 12h18M3 6h18M3 18h18"></path>
+                        </svg>
+                </button>
 		<div class="internal-links">
 			<HeaderLink href="/blockchain">Blockchain</HeaderLink>
 			<HeaderLink href="/stores">Stores</HeaderLink>
@@ -52,12 +54,18 @@ const currentPath = Astro.url.pathname;
 		margin: 0 auto;
 	}
 	
-	.logo {
-		display: flex;
-		align-items: center;
-		gap: 0.5rem;
-		text-decoration: none;
-		color: var(--black);
+        .branding {
+                display: flex;
+                align-items: center;
+                gap: 1rem;
+        }
+
+        .logo {
+                display: flex;
+                align-items: center;
+                gap: 0.5rem;
+                text-decoration: none;
+                color: var(--black);
 		font-weight: 600;
 		font-size: 1.25rem;
 		transition: opacity 0.2s;
@@ -65,17 +73,17 @@ const currentPath = Astro.url.pathname;
 	
 	.logo:hover {
 		opacity: 0.8;
-	}
-	
-	.logo img {
-		height: 2rem;
-		width: auto;
-	}
-	
-	.internal-links {
-		display: flex;
-		gap: 2rem;
-	}
+        }
+
+        .logo img {
+                height: 2rem;
+                width: auto;
+        }
+
+        .internal-links {
+                display: flex;
+                gap: 2rem;
+        }
 	
 	nav a {
 		color: var(--black);
@@ -108,27 +116,27 @@ const currentPath = Astro.url.pathname;
 		display: flex;
 	}
 	
-	@media (max-width: 640px) {
-		header {
-			position: relative;
-		}
-		
-		.internal-links {
-			display: none;
-		}
-		
-		.mobile-menu-toggle {
-			display: block;
-		}
-		
-		.logo span {
-			font-size: 1rem;
-		}
-		
-		.logo img {
-			height: 1.5rem;
-		}
-	}
+        @media (max-width: 640px) {
+                header {
+                        position: relative;
+                }
+
+                .internal-links {
+                        display: none;
+                }
+
+                .mobile-menu-toggle {
+                        display: block;
+                }
+
+                .logo span {
+                        font-size: 1rem;
+                }
+
+                .logo img {
+                        height: 1.5rem;
+                }
+        }
 </style>
 
 <script>

--- a/src/pages/blockchain.astro
+++ b/src/pages/blockchain.astro
@@ -569,6 +569,19 @@ const factoryAbiJson = JSON.stringify(CatLabFactoryABI);
         
         return (
           <div className="max-w-7xl mx-auto px-4 py-6 sm:px-6 sm:py-8 lg:px-8">
+            <div className="mb-6">
+              <div className="rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-blue-900 sm:flex sm:items-center sm:justify-between sm:gap-6">
+                <p className="text-sm font-medium sm:text-base">Visit the full FloodBoy experience:</p>
+                <a
+                  className="mt-2 block text-sm font-semibold underline break-words sm:mt-0 sm:text-base"
+                  href="https://www.cmuccdc.org/floodboy"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  https://www.cmuccdc.org/floodboy
+                </a>
+              </div>
+            </div>
             {/* Header */}
             <div className="mb-6 sm:mb-8">
               <h1 className="text-2xl font-bold text-gray-900 mb-2 sm:text-3xl">IoT Sensor Stores</h1>


### PR DESCRIPTION
## Summary
- restore the header layout by removing the full-site messaging block from the navigation bar
- surface the full FloodBoy URL in a dedicated banner at the top of the blockchain page so it appears above the IoT Sensor Stores heading

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68dc5fbf1a048328a5c611879beb6955