### PR TITLE
Relocate header banner and mobile menu

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -4,16 +4,18 @@ const currentPath = Astro.url.pathname;
 ---
 
 <header>
-	<nav>
-		<a href="/" class="logo">
-			<img src="/floodboy-logo.png" alt="Floodboy" />
-			<span>FloodBoy: IoT-Powered Blockchain</span>
-		</a>
-		<button class="mobile-menu-toggle" aria-label="Toggle menu">
-			<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-				<path d="M3 12h18M3 6h18M3 18h18"></path>
-			</svg>
-		</button>
+        <nav>
+                <div class="branding">
+                        <a href="/" class="logo">
+                                <img src="/floodboy-logo.png" alt="Floodboy" />
+                                <span>FloodBoy: IoT-Powered Blockchain</span>
+                        </a>
+                </div>
+                <button class="mobile-menu-toggle" aria-label="Toggle menu">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <path d="M3 12h18M3 6h18M3 18h18"></path>
+                        </svg>
+                </button>
 		<div class="internal-links">
 			<HeaderLink href="/blockchain">Blockchain</HeaderLink>
 			<HeaderLink href="/stores">Stores</HeaderLink>
@@ -23,41 +25,62 @@ const currentPath = Astro.url.pathname;
 			<HeaderLink href="/simulator">Simulator</HeaderLink>
 			<HeaderLink href="/blog">AI Speaking</HeaderLink>
 		</div>
-		<div class="mobile-menu">
-			<HeaderLink href="/blockchain">Blockchain</HeaderLink>
-			<HeaderLink href="/stores">Stores</HeaderLink>
-			<HeaderLink href="/opendata">Open Data</HeaderLink>
-			<HeaderLink href="/opencode">Open Code</HeaderLink>
-			<HeaderLink href="/prompts">Open Prompts</HeaderLink>
-			<HeaderLink href="/simulator">Simulator</HeaderLink>
-			<HeaderLink href="/blog">AI Speaking</HeaderLink>
-		</div>
-	</nav>
+        </nav>
+        <div class="mobile-menu">
+                <HeaderLink href="/blockchain">Blockchain</HeaderLink>
+                <HeaderLink href="/stores">Stores</HeaderLink>
+                <HeaderLink href="/opendata">Open Data</HeaderLink>
+                <HeaderLink href="/opencode">Open Code</HeaderLink>
+                <HeaderLink href="/prompts">Open Prompts</HeaderLink>
+                <HeaderLink href="/simulator">Simulator</HeaderLink>
+                <HeaderLink href="/blog">AI Speaking</HeaderLink>
+        </div>
+        <div class="main-site-banner" role="presentation">
+                <span class="main-site-copy">Full FloodBoy site:</span>
+                <a
+                        class="main-site-link"
+                        href="https://www.cmuccdc.org/floodboy"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                >
+                        https://www.cmuccdc.org/floodboy
+                </a>
+        </div>
 </header>
 <style>
-	header {
-		margin: 0;
-		padding: 0 1em;
-		background: white;
-		box-shadow: 0 2px 8px rgba(var(--black), 5%);
-		border-bottom: 1px solid #e5e7eb;
-	}
+        header {
+                margin: 0;
+                padding: 0 1em 0.5rem;
+                background: white;
+                box-shadow: 0 2px 8px rgba(var(--black), 5%);
+                border-bottom: 1px solid #e5e7eb;
+                display: flex;
+                flex-direction: column;
+                gap: 0.5rem;
+        }
+
+        nav {
+                display: flex;
+                align-items: center;
+                justify-content: space-between;
+                height: 4rem;
+                max-width: 80rem;
+                margin: 0 auto;
+                width: 100%;
+        }
 	
-	nav {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		height: 4rem;
-		max-width: 80rem;
-		margin: 0 auto;
-	}
-	
-	.logo {
-		display: flex;
-		align-items: center;
-		gap: 0.5rem;
-		text-decoration: none;
-		color: var(--black);
+        .branding {
+                display: flex;
+                align-items: center;
+                gap: 1rem;
+        }
+
+        .logo {
+                display: flex;
+                align-items: center;
+                gap: 0.5rem;
+                text-decoration: none;
+                color: var(--black);
 		font-weight: 600;
 		font-size: 1.25rem;
 		transition: opacity 0.2s;
@@ -65,17 +88,17 @@ const currentPath = Astro.url.pathname;
 	
 	.logo:hover {
 		opacity: 0.8;
-	}
-	
-	.logo img {
-		height: 2rem;
-		width: auto;
-	}
-	
-	.internal-links {
-		display: flex;
-		gap: 2rem;
-	}
+        }
+
+        .logo img {
+                height: 2rem;
+                width: auto;
+        }
+
+        .internal-links {
+                display: flex;
+                gap: 2rem;
+        }
 	
 	nav a {
 		color: var(--black);
@@ -91,44 +114,101 @@ const currentPath = Astro.url.pathname;
 		color: var(--black);
 	}
 	
-	.mobile-menu {
-		display: none;
-		position: absolute;
-		top: 100%;
-		left: 0;
-		right: 0;
-		background: white;
-		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-		padding: 1rem;
-		flex-direction: column;
-		gap: 1rem;
-	}
-	
-	.mobile-menu.active {
-		display: flex;
-	}
-	
-	@media (max-width: 640px) {
-		header {
-			position: relative;
-		}
-		
-		.internal-links {
-			display: none;
-		}
-		
-		.mobile-menu-toggle {
-			display: block;
-		}
-		
-		.logo span {
-			font-size: 1rem;
-		}
-		
-		.logo img {
-			height: 1.5rem;
-		}
-	}
+        .mobile-menu {
+                display: none;
+                background: white;
+                border: 1px solid #e5e7eb;
+                border-radius: 0.5rem;
+                padding: 1rem;
+                flex-direction: column;
+                gap: 1rem;
+                width: 100%;
+                max-width: 80rem;
+                margin: 0 auto;
+                box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+                box-sizing: border-box;
+        }
+
+        .mobile-menu.active {
+                display: flex;
+        }
+
+        .main-site-banner {
+                display: flex;
+                flex-wrap: wrap;
+                align-items: center;
+                gap: 0.35rem 0.75rem;
+                font-size: 0.9rem;
+                max-width: 80rem;
+                margin: 0 auto;
+                width: 100%;
+                padding: 0.35rem 0;
+        }
+
+        .main-site-copy {
+                color: var(--black);
+                font-weight: 500;
+        }
+
+        .main-site-link {
+                color: var(--black);
+                font-weight: 600;
+                word-break: break-word;
+                text-decoration: underline;
+                transition: opacity 0.2s;
+        }
+
+        .main-site-link:hover,
+        .main-site-link:focus {
+                opacity: 0.8;
+        }
+
+        @media (max-width: 640px) {
+                header {
+                        position: relative;
+                        padding-bottom: 0.75rem;
+                }
+
+                .branding {
+                        gap: 0.75rem;
+                        align-items: flex-start;
+                }
+
+                .internal-links {
+                        display: none;
+                }
+
+                .mobile-menu-toggle {
+                        display: block;
+                }
+
+                .logo span {
+                        font-size: 1rem;
+                }
+
+                .logo img {
+                        height: 1.5rem;
+                }
+
+                .main-site-banner {
+                        font-size: 0.85rem;
+                        align-items: flex-start;
+                }
+
+                .main-site-copy {
+                        font-size: 0.75rem;
+                }
+
+                .main-site-link {
+                        font-size: 0.85rem;
+                }
+        }
+
+        @media (min-width: 641px) {
+                .mobile-menu {
+                        display: none !important;
+                }
+        }
 </style>
 
 <script>


### PR DESCRIPTION
## Summary
- move the mobile navigation out of the nav bar so it expands above the page content instead of overlaying it
- place the full main-site message in its own banner row beneath the header for clearer desktop and mobile layout
- refresh related styling so the stacked header sections stay aligned within the 80rem content width
- clarify the main-site banner copy so it simply presents the FloodBoy URL information

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68dc5fbf1a048328a5c611879beb6955